### PR TITLE
Dockerise

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+yarn-debug.log
+docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /usr/src/app
 
 COPY package.json ./
 
-#RUN apk add --no-cache --virtual .gyp python make g++
-
 # Git required for npm / yarn
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
@@ -21,11 +19,10 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl \
 
 COPY .env.example .env
 RUN yarn install
-#RUN apk del .gyp
 
 COPY . .
 
-RUN yarn dev:build
+RUN yarn build
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:8.10-alpine
+
+WORKDIR /usr/src/app
+
+COPY package.json ./
+
+#RUN apk add --no-cache --virtual .gyp python make g++
+
+# Git required for npm / yarn
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+# Yarn
+RUN apk add --no-cache --virtual .build-deps-yarn curl \
+    && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+    && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+    && rm yarn-v$YARN_VERSION.tar.gz \
+    && apk del .build-deps-yarn
+
+COPY .env.example .env
+RUN yarn install
+#RUN apk del .gyp
+
+COPY . .
+
+RUN yarn dev:build
+
+EXPOSE 8080
+
+USER node
+CMD ["node", "dist/start.js"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ If you just want to do both in one:
 yarn dev
 ```
 
+## Docker
+
+Dockerfile included for local development.  Refer to https://github.com/brandsExclusive/infra-le-local-dev for instructions with Docker Compose.
+
 ## Production
 
 Start server:

--- a/dist/server.js
+++ b/dist/server.js
@@ -86,6 +86,7 @@ exports.getServer = function () {
       marginLeft: 0,
       marginRight: 0,
       dpi: 300,
+      encoding: 'utf8',
       title: 'Luxury Escapes Gift Card',
       debug: debug
     };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node dist/start.js",
+    "build": "babel src --out-dir dist",
     "dev": "yarn dev:build & yarn dev:start",
     "dev:start": "nodemon dist/start.js",
     "dev:build": "babel src --out-dir dist --watch",


### PR DESCRIPTION
Added Dockerfile as local development option.

This is used by brandsExclusive/infra-le-local-dev#43 as a convenient way of running all backend services locally.

Developer adoption is voluntary - normal local development as per README.md is fully supported and encouraged.